### PR TITLE
Use topkg, expose github-hooks.unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 *~
 *.native
+github-hooks.install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,3 @@
+### 0.1.0 (unreleased)
+
+- initial release, extracted from datakit which was extracted from ocaml-github

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,3 @@
 ### 0.1.0 (unreleased)
 
-- initial release, extracted from datakit which was extracted from ocaml-github
+- initial release, extracted from datakit, itself extracted from ocamlot

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,14 @@
+Copyright (c) 2013-2016 David Sheets <sheets@alum.mit.edu>
+Copyright (c) 2016 Thomas Gazagnaire <thomas@gazagnaire.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/META
+++ b/META
@@ -1,8 +1,0 @@
-version = "0.1.0"
-description = "Github API web hook listener library"
-requires = "fmt logs lwt cohttp.lwt-core conduit.lwt github nocrypto hex"
-archive(byte) = "github_hooks.cma"
-archive(byte, plugin) = "github_hooks.cma"
-archive(native) = "github_hooks.cmxa"
-archive(native, plugin) = "github_hooks.cmxs"
-exists_if = "github_hooks.cma"

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,13 @@
-.PHONY: build test install uninstall reinstall clean
+.PHONY: build test clean
 
-FINDLIB_NAME=github-hooks
-MOD_NAME=github_hooks
-
-OCAMLBUILD=ocamlbuild -use-ocamlfind -classic-display
-
-WITH_UNIX=$(shell ocamlfind query unix > /dev/null 2>&1 ; echo $$?)
-
-TARGETS=.cma .cmxa .cmx
-
-PRODUCTS=$(addprefix $(MOD_NAME),$(TARGETS))
-
-ifeq ($(WITH_UNIX), 0)
-PRODUCTS+=$(addprefix $(MOD_NAME)_unix,$(TARGETS))
-endif
-
-TYPES=.mli .cmi .cmti
-
-INSTALL:=$(addprefix $(MOD_NAME), $(TYPES)) \
-         $(addprefix $(MOD_NAME), $(TARGETS))
-
-INSTALL:=$(addprefix _build/lib/,$(INSTALL))
-
-ifeq ($(WITH_UNIX), 0)
-INSTALL_UNIX:=$(addprefix $(MOD_NAME)_unix,$(TYPES) $(TARGETS))
-INSTALL_UNIX:=$(addprefix _build/unix/,$(INSTALL_UNIX))
-
-INSTALL+=$(INSTALL_UNIX)
-endif
-
-ARCHIVES:=_build/lib/$(MOD_NAME).a
-
-ifeq ($(WITH_UNIX), 0)
-ARCHIVES+=_build/unix/$(MOD_NAME)_unix.a
-endif
+TESTS  ?= true
+OPTIONS=--tests ${TESTS}
 
 build:
-	$(OCAMLBUILD) $(PRODUCTS)
+	ocaml pkg/pkg.ml build ${OPTIONS}
 
 test: build
-	$(OCAMLBUILD) test/test_hook_server.native
-	./test_hook_server.native
-
-install:
-	ocamlfind install $(FINDLIB_NAME) META \
-		$(INSTALL) \
-		$(ARCHIVES)
-
-uninstall:
-	ocamlfind remove $(FINDLIB_NAME)
-
-reinstall: uninstall install
+	ocaml pkg/pkg.ml test
 
 clean:
-	ocamlbuild -clean
+	ocaml pkg/pkg.ml clean

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## github-hooks
 
-Github API web hook listener library.
+GitHub API web hook listener library.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## github-hooks
+
+Github API web hook listener library.

--- a/_tags
+++ b/_tags
@@ -3,3 +3,7 @@ true: principal, bin_annot, safe_string, strict_sequence, debug
 
 "lib": include
 "unix": include
+
+<lib/*>: package(fmt logs lwt cohttp conduit.lwt github nocrypto hex)
+<unix/*>: package(lwt.unix)
+<test/*>: package(logs re lwt.unix github.unix cohttp.lwt hex fmt)

--- a/doc/api.odocl
+++ b/doc/api.odocl
@@ -1,0 +1,2 @@
+Github_hooks
+Github_hooks_unix

--- a/lib/_tags
+++ b/lib/_tags
@@ -1,1 +1,0 @@
-<*.*>: package(fmt, logs, lwt, cohttp, conduit.lwt, github, nocrypto, hex)

--- a/lib/github-hooks.mllib
+++ b/lib/github-hooks.mllib
@@ -1,0 +1,1 @@
+Github_hooks

--- a/opam
+++ b/opam
@@ -9,20 +9,15 @@ authors: [
 homepage: "https://github.com/dsheets/ocaml-github-hooks"
 bug-reports: "https://github.com/dsheets/ocaml-github-hooks/issues"
 dev-repo: "https://github.com/dsheets/ocaml-github-hooks.git"
+doc: "https://dsheets.github.io/ocaml-github-hooks/"
+
 tags: [
   "git"
   "github"
 ]
-build: [
-  [make]
-]
-install: [
-  [make "install"]
-]
-remove: [
-  ["ocamlfind" "remove" "github-hooks"]
-]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
+  "topkg" { build }
   "ocamlfind" { build }
   "base-unix"
   "fmt"

--- a/pkg/META
+++ b/pkg/META
@@ -1,0 +1,18 @@
+description = "Github API web hook listener library"
+version = "%%VERSION%%"
+requires = "fmt logs lwt cohttp.lwt-core conduit.lwt github nocrypto hex"
+archive(byte)   = "github-hooks.cma"
+archive(native) = "github-hooks.cmxa"
+plugin(byte)    = "github-hooks.cma"
+plugin(native)  = "github-hooks.cmxs"
+
+package "unix" (
+ description = "Unix backend for the Github API web hook listener"
+ version = "%%VERSION%%"
+ requires = "github-hooks lwt.unix"
+ archive(byte)   = "github-hooks-unix.cma"
+ archive(native) = "github-hooks-unix.cmxa"
+ plugin(byte)    = "github-hooks-unix.cma"
+ plugin(native)  = "github-hooks-unix.cmxs"
+ exists_if       = "github-hooks-unix.cma"
+)

--- a/pkg/META
+++ b/pkg/META
@@ -1,4 +1,4 @@
-description = "Github API web hook listener library"
+description = "GitHub API web hook listener library"
 version = "%%VERSION%%"
 requires = "fmt logs lwt cohttp.lwt-core conduit.lwt github nocrypto hex"
 archive(byte)   = "github-hooks.cma"
@@ -7,7 +7,7 @@ plugin(byte)    = "github-hooks.cma"
 plugin(native)  = "github-hooks.cmxs"
 
 package "unix" (
- description = "Unix backend for the Github API web hook listener"
+ description = "Unix backend for the GitHub API web hook listener"
  version = "%%VERSION%%"
  requires = "github-hooks lwt.unix"
  archive(byte)   = "github-hooks-unix.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,0 +1,14 @@
+#!/usr/bin/env ocaml
+#use "topfind"
+#require "topkg"
+open Topkg
+
+let opams = [Pkg.opam_file ~lint_deps_excluding:None "opam"]
+
+let () =
+  Pkg.describe ~opams "github-hooks" @@ fun c ->
+  Ok [
+    Pkg.mllib "lib/github-hooks.mllib";
+    Pkg.mllib "unix/github-hooks-unix.mllib";
+    Pkg.test "test/test_hook_server"
+  ]

--- a/test/_tags
+++ b/test/_tags
@@ -1,1 +1,0 @@
-<*.*>: package(logs, re, lwt.unix, github.unix, cohttp.lwt, hex, fmt)

--- a/unix/github-hooks-unix.mllib
+++ b/unix/github-hooks-unix.mllib
@@ -1,0 +1,1 @@
+Github_hooks_unix


### PR DESCRIPTION
It seems to build fine and I can now compile datakit with `github-hooks.unix`. Running the tests gives me: 

```
Fatal error: exception (Failure
  "usage: /Users/thomas/git/ocaml-github-hooks/_build/test/test_hook_server.native server_uri user repo collaborator")
```

because I don't have the right access I guess.

Also I haven't tried uploading the doc online (using `topkg publish doc`) because I don't have access to that repo.
