### PR TITLE
Update for github 2.0.1 which fixes a GitHub web hook bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ script: bash -ex .travis-opam.sh
 env:
   - OCAML_VERSION=4.02 PACKAGE=github-hooks
   - OCAML_VERSION=4.03 PACKAGE=github-hooks
-  - OCAML_VERSION=4.04 PACKAGE=github-hooks
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.00 PACKAGE=github-hooks
+  - OCAML_VERSION=4.01 PACKAGE=github-hooks
+  - OCAML_VERSION=4.02 PACKAGE=github-hooks
+  - OCAML_VERSION=4.03 PACKAGE=github-hooks
+  - OCAML_VERSION=4.04 PACKAGE=github-hooks
+os:
+  - linux
+  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.00 PACKAGE=github-hooks
-  - OCAML_VERSION=4.01 PACKAGE=github-hooks
   - OCAML_VERSION=4.02 PACKAGE=github-hooks
   - OCAML_VERSION=4.03 PACKAGE=github-hooks
   - OCAML_VERSION=4.04 PACKAGE=github-hooks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 0.1.1
+
+- Update for github 2.0.1 which fixes a GitHub hook config type issue
+
 ### 0.1.0
 
 - initial release, extracted from datakit, itself extracted from ocamlot

--- a/lib/github_hooks.ml
+++ b/lib/github_hooks.ml
@@ -196,7 +196,7 @@ module Make(Time : TIME)(Conf : CONFIGURATION) = struct
       in
       let new_hook_config = `Web {
         web_hook_config_url          = Uri.to_string url;
-        web_hook_config_content_type = "json";
+        web_hook_config_content_type = Some "json";
         web_hook_config_insecure_ssl = insecure_ssl;
         web_hook_config_secret       = Some (Cstruct.to_string secret);
       }

--- a/opam
+++ b/opam
@@ -26,3 +26,4 @@ depends: [
   "nocrypto"
   "hex"
 ]
+available: [ ocaml-version >= "4.02.0" ]

--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github" {>= "2.0.0"}
+  "github" {>= "2.0.1"}
   "nocrypto"
   "hex"
 ]


### PR DESCRIPTION
I think this is sufficient to prepare for 0.1.1 but I'm new to topkg. @samoht what else do I need to do?
