### PR TITLE
Fix META file

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -9,7 +9,7 @@ plugin(native)  = "github-hooks.cmxs"
 package "unix" (
  description = "Unix backend for the GitHub API web hook listener"
  version = "%%VERSION%%"
- requires = "github.unix lwt.unix github-hooks"
+ requires = "github github.unix lwt.unix github-hooks"
  archive(byte)   = "github-hooks-unix.cma"
  archive(native) = "github-hooks-unix.cmxa"
  plugin(byte)    = "github-hooks-unix.cma"


### PR DESCRIPTION
The github library needs a weird linking trick: it needs to have `github.unix`
specified before `github` -- as some tools can reorder the findlinb deps, be
sure that `github` has a `github.unix` on both sides ...