### PR TITLE
Use ocaml-github dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PINS="github-hooks.dev:. github-hooks-unix.dev:."
+  - PINS="github.dev:--dev github-unix.dev:https://github.com/mirage/ocaml-github.git  github-hooks.dev:. github-hooks-unix.dev:."
   matrix:
   - OCAML_VERSION=4.02 PACKAGE=github-hooks-unix
   - OCAML_VERSION=4.03 PACKAGE=github-hooks-unix

--- a/github-hooks.opam
+++ b/github-hooks.opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lwt"
   "cohttp"
-  "github" {>= "2.0.1"}
+  "github-unix" {>= "3.0.0"}
   "conduit"
   "nocrypto"
   "hex"

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -3,4 +3,5 @@
 (library
   ((name        github_hooks)
    (public_name github-hooks)
-   (libraries   (github cohttp logs fmt lwt conduit.lwt cstruct nocrypto hex))))
+   (libraries   (github-unix cohttp logs fmt lwt conduit.lwt cstruct nocrypto
+                 hex))))

--- a/test/jbuild
+++ b/test/jbuild
@@ -2,4 +2,4 @@
 
 (executable
   ((name      test_hook_server)
-   (libraries (github-hooks-unix github.unix))))
+   (libraries (github-hooks-unix github-unix))))


### PR DESCRIPTION
Not very happy with adding a dependency to `github-unix` instead of `github`, but this is needed until we have https://github.com/janestreet/jbuilder/issues/136