### PR TITLE
Add support for Lwt>=4 and upgrade build system to Dune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 *~
 *.install
 *.merlin
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ env:
   global:
   - PINS="github.dev:--dev github-unix.dev:--dev  github-hooks.dev:. github-hooks-unix.dev:."
   matrix:
-  - OCAML_VERSION=4.03 PACKAGE=github-hooks-unix
-  - OCAML_VERSION=4.04 PACKAGE=github-hooks-unix
   - OCAML_VERSION=4.05 PACKAGE=github-hooks-unix
+  - OCAML_VERSION=4.06 PACKAGE=github-hooks-unix
+  - OCAML_VERSION=4.07 PACKAGE=github-hooks-unix
 os:
   - linux
   - osx

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 0.4.0
+
+- Support Lwt >= 4.0.0 (@avsm)
+- Upgrade build system from jbuilder to dune (@avsm)
+
 ### 0.3.0
 
 - Support cohttp 1.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: all test clean
 
 all:
-	jbuilder build --dev
+	dune build
 
 test:
-	jbuilder build --dev test/test_hook_server.exe
+	dune build test/test_hook_server.exe
 
 clean:
-	jbuilder clean
+	dune clean

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name github-hooks)

--- a/github-hooks-unix.opam
+++ b/github-hooks-unix.opam
@@ -15,15 +15,15 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 
 depends: [
-  "jbuilder"         { build & >= "1.0+beta9" }
+  "dune"             {build}
   "github-unix"      {>= "3.0.1"}
   "conduit-lwt-unix" {>= "1.0.0"}
-  "github-hooks"     {>= "0.2.0"}
+  "github-hooks"     {>= "0.3.0"}
   "cohttp-lwt-unix"  {>= "0.99.0"}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/github-hooks.opam
+++ b/github-hooks.opam
@@ -15,12 +15,12 @@ tags: [
 ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 
 depends: [
-  "jbuilder" { build & >= "1.0+beta9"}
+  "dune" {build}
   "fmt"
   "logs"
   "lwt"

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,0 +1,4 @@
+(library
+  (name        github_hooks)
+  (public_name github-hooks)
+  (libraries   github cohttp logs fmt lwt lwt.unix cstruct nocrypto hex))

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -1,6 +1,0 @@
-(jbuild_version 1)
-
-(library
-  ((name        github_hooks)
-   (public_name github-hooks)
-   (libraries   (github cohttp logs fmt lwt lwt.unix cstruct nocrypto hex))))

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -3,4 +3,4 @@
 (library
   ((name        github_hooks)
    (public_name github-hooks)
-   (libraries   (github cohttp logs fmt lwt cstruct nocrypto hex))))
+   (libraries   (github cohttp logs fmt lwt lwt.unix cstruct nocrypto hex))))

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -1,0 +1,4 @@
+(library
+  (name        github_hooks_unix)
+  (public_name github-hooks-unix)
+  (libraries   github-hooks github-unix conduit-lwt-unix lwt.unix))

--- a/src/unix/jbuild
+++ b/src/unix/jbuild
@@ -1,6 +1,0 @@
-(jbuild_version 1)
-
-(library
-  ((name        github_hooks_unix)
-   (public_name github-hooks-unix)
-   (libraries   (github-hooks github-unix conduit-lwt-unix lwt.unix))))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(executable
+  (name      test_hook_server)
+  (libraries github-hooks-unix github-unix))

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,5 +1,0 @@
-(jbuild_version 1)
-
-(executable
-  ((name      test_hook_server)
-   (libraries (github-hooks-unix github-unix))))


### PR DESCRIPTION
Note that this dependency on Unix is probably a bug in github-hooks, since the core library is not meant to be depend on Unix, but that fix is a bigger one since it requires propagating a timeout function through the module.  This PR just fixes the build for now.
