### PR TITLE
support conduit >= 1.5.0 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PINS="github.dev:--dev github-unix.dev:--dev  github-hooks.dev:. github-hooks-unix.dev:."
+  - PINS="github-hooks.dev:. github-hooks-unix.dev:."
   matrix:
   - OCAML_VERSION=4.05 PACKAGE=github-hooks-unix
   - OCAML_VERSION=4.06 PACKAGE=github-hooks-unix
   - OCAML_VERSION=4.07 PACKAGE=github-hooks-unix
+  - OCAML_VERSION=4.08 PACKAGE=github-hooks-unix
 os:
   - linux
   - osx

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 0.5.0
+
+- Support conduit >= 1.5.0 (@avsm)
+
 ### 0.4.0
 
 - Support Lwt >= 4.0.0 (@avsm)

--- a/github-hooks-unix.opam
+++ b/github-hooks-unix.opam
@@ -20,10 +20,10 @@ build: [
 ]
 
 depends: [
-  "dune"             {build}
+  "dune"
   "github-unix"      {>= "3.0.1"}
-  "conduit-lwt-unix" {>= "1.0.0"}
-  "github-hooks"     {>= "0.3.0"}
+  "conduit-lwt-unix" {>= "1.5.0"}
+  "github-hooks"     {=version}
   "cohttp-lwt-unix"  {>= "0.99.0"}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/github-hooks.opam
+++ b/github-hooks.opam
@@ -20,11 +20,12 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "fmt"
   "logs"
   "lwt"
   "cohttp-lwt" {>= "0.99.0"}
+  "conduit-lwt" {>= "1.5.0"}
   "github" {>= "3.0.1"}
   "nocrypto"
   "cstruct"

--- a/src/core/github_hooks.ml
+++ b/src/core/github_hooks.ml
@@ -17,7 +17,7 @@ module Repo = struct
     end)
 end
 
-type tls_config =
+type server_tls_config =
   [ `Crt_file_path of string ] *
   [ `Key_file_path of string ] *
   [ `Password of bool -> string | `No_password ] *
@@ -26,7 +26,7 @@ type tls_config =
 module type CONFIGURATION = sig
   module Log : Logs.LOG
   val secret_prefix : string
-  val tls_config : (int -> tls_config) option
+  val tls_config : (int -> server_tls_config) option
 end
 
 module type TIME = sig
@@ -49,7 +49,8 @@ end
 
 module type SERVER = sig
   include Cohttp_lwt.S.Server
-  type mode = private [> `TCP of [`Port of int] | `TLS of tls_config]
+  type tcp_config = private [> `Port of int ]
+  type mode = private [> `TCP of tcp_config | `TLS of server_tls_config]
   val create: mode -> t -> unit Lwt.t
 end
 

--- a/src/core/github_hooks.mli
+++ b/src/core/github_hooks.mli
@@ -2,7 +2,7 @@
 
 (** The type for TLS server configuration. Similar to
     [Conduit_lwt_unix.server_tls_config] *)
-type tls_config =
+type server_tls_config =
   [ `Crt_file_path of string ] *
   [ `Key_file_path of string ] *
   [ `Password of bool -> string | `No_password ] *
@@ -16,7 +16,7 @@ end
 module type CONFIGURATION = sig
   module Log : Logs.LOG
   val secret_prefix : string
-  val tls_config : (int -> tls_config) option
+  val tls_config : (int -> server_tls_config) option
 end
 
 module type TIME = sig
@@ -27,7 +27,8 @@ end
 
 module type SERVER = sig
   include Cohttp_lwt.S.Server
-  type mode = private [> `TCP of [`Port of int] | `TLS of tls_config]
+  type tcp_config = private [> `Port of int ]
+  type mode = private [> `TCP of tcp_config | `TLS of server_tls_config]
   val create: mode -> t -> unit Lwt.t
 end
 

--- a/src/unix/github_hooks_unix.ml
+++ b/src/unix/github_hooks_unix.ml
@@ -6,6 +6,7 @@ end
 
 module Server = struct
   include Cohttp_lwt_unix.Server
+  type tcp_config = Conduit_lwt_unix.tcp_config
   type mode = Conduit_lwt_unix.server
   let create mode t = create ~mode:(mode :> mode) t
 end

--- a/src/unix/github_hooks_unix.mli
+++ b/src/unix/github_hooks_unix.mli
@@ -2,7 +2,8 @@ open Github_hooks
 
 module Time: TIME
 
-module Server: SERVER with type mode = Conduit_lwt_unix.server
-  [@@ warning "-34"]
+module Server: SERVER with
+  type tcp_config = Conduit_lwt_unix.tcp_config and
+  type mode = Conduit_lwt_unix.server
 
 module Make (Conf: CONFIGURATION): HOOKS with type token = Github.Token.t


### PR DESCRIPTION
The underlying server type parameters were extended to support
starting a server from an existing fd (e.g. from systemd) so some
new type names appeared